### PR TITLE
Support custom subdomain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,18 +466,32 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
-      "integrity": "sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
+      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==",
       "dev": true
     },
     "@types/node-fetch": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
-      "integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.5.tgz",
+      "integrity": "sha512-IWwjsyYjGw+em3xTvWVQi5MgYKbRs0du57klfTaZkv/B24AEQ/p/IopNeqIYNy3EsfHOpg8ieQSDomPcsYMHpA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/stack-utils": {
@@ -524,9 +538,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -581,9 +595,9 @@
       }
     },
     "arg": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "arr-diff": {
@@ -1011,9 +1025,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "optional": true
     },
@@ -1201,9 +1215,9 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
     "diff-sequences": {
@@ -2215,9 +2229,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+      "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -3190,9 +3204,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {
@@ -4626,16 +4640,16 @@
       }
     },
     "ts-node": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
-      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
+      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
+        "yn": "3.1.1"
       }
     },
     "tunnel-agent": {
@@ -4663,19 +4677,19 @@
       }
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
-      "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",
-    "@types/node": "^12.7.12",
-    "@types/node-fetch": "^2.5.2",
+    "@types/node": "^13.9.0",
+    "@types/node-fetch": "^2.5.5",
     "dotenv": "^8.1.0",
     "jest": "24.9.0",
     "ts-jest": "24.1.0",
-    "ts-node": "8.4.1",
-    "typescript": "^3.6.4"
+    "ts-node": "^8.6.2",
+    "typescript": "^3.8.3"
   }
 }

--- a/src/batcher/index.ts
+++ b/src/batcher/index.ts
@@ -1,14 +1,17 @@
 import { Botmock } from "../";
 import { EventEmitter } from "events";
+import { ClientConfig } from "../";
 
 interface Config {
-  token: string;
-  teamId: string;
-  projectId: string;
-  boardId: string;
+  clientConfig: ClientConfig;
+  projectConfig: {
+    teamId: string;
+    projectId: string;
+    boardId?: string;
+  };
 }
 
-export type JSONResponse = { [assetName: string]: any };
+export type JSONResponse = { [assetName: string]: any; };
 
 export type ResourceMap = Map<string, string>;
 
@@ -30,10 +33,13 @@ export default class extends EventEmitter {
    */
   constructor(config: Config) {
     super();
-    this.teamId = config.teamId;
-    this.boardId = config.boardId;
-    this.projectId = config.projectId;
-    this.client = new Botmock({ token: config.token });
+    const { teamId, boardId, projectId } = config.projectConfig;
+    this.teamId = teamId;
+    this.boardId = boardId;
+    this.projectId = projectId;
+    this.client = new Botmock({
+      ...config.clientConfig,
+    });
     this.client.on("error", (err: Error) => {
       throw err;
     });
@@ -43,12 +49,12 @@ export default class extends EventEmitter {
    * @param resourceNames string[]
    * @returns Promise<null | { data: JSONResponse }>
    */
-  public async batchRequest(resourceNames: string[]): Promise<null | { data: JSONResponse }> {
+  public async batchRequest(resourceNames: string[]): Promise<null | { data: JSONResponse; }> {
     try {
       const { teamId, projectId, boardId } = this;
       const data = await Promise.all(resourceNames.map(async resourceName => {
         const method = this.resourceMethodMap.get(resourceName);
-        const argument: Partial<Config> = { projectId, teamId };
+        const argument: Config["projectConfig"] = { projectId, teamId };
         if (resourceName === "board") {
           argument.boardId = boardId;
         }

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -2,7 +2,7 @@ import fetch, { FetchError } from "node-fetch";
 import { EventEmitter } from "events";
 import { Agent } from "https";
 
-interface Config {
+export interface Config {
   token: string;
   subdomain?: string;
   shouldRejectUnauthorized?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default as Botmock } from "./fetcher";
+export { default as Botmock, Config as ClientConfig } from "./fetcher";
 export { default as Batcher } from "./batcher";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { Botmock, Batcher } from "../src";
-import { URL } from "../src/fetcher";
+
+const URL = "https://app.botmock.com/api";
 
 describe("batcher", () => {
   test("creates instance of class when called with new", () => {
@@ -25,9 +26,6 @@ describe("setup", () => {
       // @ts-ignore
       const client = new Botmock();
     }).toThrow();
-  });
-  test("has static url", () => {
-    expect(Botmock.URL).toBe(URL);
   });
 });
 
@@ -72,4 +70,4 @@ describe("methods", () => {
   });
 });
 
-describe.skip("error handling", () => {});
+describe.skip("error handling", () => { });


### PR DESCRIPTION
This PR allows the client to accept a `subdomain` in its config object in order for custom Botmock subdomains to be accessed.

It also allows boolean `shouldRejectUnauthorized` to be passed to the constructor. If this value is defined, a custom `Agent` will be passed to `node-fetch` with a corresponding `rejectUnauthorized` value.

### Example
```ts
const client = new Botmock({
  token: "token",
  subdomain: "ww2",
  shouldRejectUnauthorized: false,
});
```