### PR TITLE
Accept full agent in config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,9 +466,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==",
+      "version": "13.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",
-    "@types/node": "^13.9.0",
+    "@types/node": "^13.9.1",
     "@types/node-fetch": "^2.5.5",
     "dotenv": "^8.1.0",
     "jest": "24.9.0",

--- a/src/fetcher/index.ts
+++ b/src/fetcher/index.ts
@@ -4,8 +4,8 @@ import { Agent } from "https";
 
 export interface Config {
   token: string;
+  agent?: Agent;
   subdomain?: string;
-  shouldRejectUnauthorized?: boolean;
 }
 
 interface ProjectOpt {
@@ -32,10 +32,8 @@ export default class Botmock extends EventEmitter {
     }
     this.token = config.token;
     this.#url = `https://${config.subdomain ?? "app"}.botmock.com/api`;
-    if (typeof config.shouldRejectUnauthorized !== "undefined") {
-      this.#agent = new Agent({
-        rejectUnauthorized: config.shouldRejectUnauthorized,
-      });
+    if (config.agent instanceof Agent) {
+      this.#agent = config.agent;
     }
   }
   /**


### PR DESCRIPTION
This PR allows for a full [agent](https://nodejs.org/dist/latest-v12.x/docs/api/http.html#http_new_agent_options) to be passed as part of the configuration object.